### PR TITLE
add test, fix for initial argument discrepancy

### DIFF
--- a/breathe/directives.py
+++ b/breathe/directives.py
@@ -137,7 +137,7 @@ class DoxygenFunctionDirective(BaseDirective):
         return self.render(node_stack, project_info, filter_, target_handler, NullMaskFactory(),
                            self.directive_args)
 
-    def parse_args(self, function_description, strip_init=False):
+    def parse_args(self, function_description):
         if function_description == '':
             function_description = '()'
 
@@ -152,8 +152,7 @@ class DoxygenFunctionDirective(BaseDirective):
                 declarator = declarator.next
             assert hasattr(declarator, 'declId')
             declarator.declId = None
-            if strip_init:
-                p.arg.init = None
+            p.arg.init = None
         return paramQual
 
     def create_function_signature(self, node_stack, project_info, filter_, target_handler,
@@ -232,10 +231,6 @@ class DoxygenFunctionDirective(BaseDirective):
             if args == match_args:
                 return entry
 
-            # Try again without initial arguments
-            match_args = self.parse_args(_match_args, strip_init=True)
-            if args == match_args:
-                return entry
         raise UnableToResolveFunctionError(signatures)
 
 

--- a/tests/data/arange.xml
+++ b/tests/data/arange.xml
@@ -1,0 +1,149 @@
+<sectiondef kind="typedef">
+<memberdef kind="function" id="1" prot="public" static="no" const="yes" explicit="no" inline="no" virt="non-virtual">
+  <type><ref refid="classat_1_1_tensor" kindref="compound">Tensor</ref></type>
+  <definition>Tensor at::arange</definition>
+  <argsstring>(Scalar end, const TensorOptions &amp;options={})</argsstring>
+  <name>arange</name>
+  <param>
+    <type>Scalar</type>
+    <declname>end</declname>
+  </param>
+  <param>
+    <type>const TensorOptions &amp;</type>
+    <declname>options</declname>
+    <defval>{}</defval>
+  </param>
+</memberdef>
+<memberdef kind="function" id="2" prot="public" static="no" const="yes" explicit="no" inline="no" virt="non-virtual">
+  <type><ref refid="classat_1_1_tensor" kindref="compound">Tensor</ref></type>
+  <definition>Tensor at::arange</definition>
+  <argsstring>(Scalar end, c10::optional&lt; ScalarType &gt; dtype, c10::optional&lt; Layout &gt; layout, c10::optional&lt; Device &gt; device, c10::optional&lt; bool &gt; pin_memory)</argsstring>
+  <name>arange</name>
+  <param>
+    <type>Scalar</type>
+    <declname>end</declname>
+  </param>
+  <param>
+    <type><ref refid="classc10_1_1optional" kindref="compound">c10::optional</ref>&lt; ScalarType &gt;</type>
+    <declname>dtype</declname>
+  </param>
+  <param>
+    <type><ref refid="classc10_1_1optional" kindref="compound">c10::optional</ref>&lt; Layout &gt;</type>
+    <declname>layout</declname>
+  </param>
+  <param>
+    <type><ref refid="classc10_1_1optional" kindref="compound">c10::optional</ref>&lt; Device &gt;</type>
+    <declname>device</declname>
+  </param>
+  <param>
+    <type><ref refid="classc10_1_1optional" kindref="compound">c10::optional</ref>&lt; bool &gt;</type>
+    <declname>pin_memory</declname>
+  </param>
+</memberdef>
+<memberdef kind="function" id="3" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+  <type><ref refid="classat_1_1_tensor" kindref="compound">Tensor</ref></type>
+  <definition>Tensor at::arange</definition>
+  <argsstring>(Scalar start, Scalar end, const TensorOptions &amp;options={})</argsstring>
+  <name>arange</name>
+  <param>
+    <type>Scalar</type>
+    <declname>start</declname>
+  </param>
+  <param>
+    <type>Scalar</type>
+    <declname>end</declname>
+  </param>
+  <param>
+    <type>const TensorOptions &amp;</type>
+    <declname>options</declname>
+    <defval>{}</defval>
+  </param>
+</memberdef>
+<memberdef kind="function" id="4" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+  <type><ref refid="classat_1_1_tensor" kindref="compound">Tensor</ref></type>
+  <definition>Tensor at::arange</definition>
+  <argsstring>(Scalar start, Scalar end, c10::optional&lt; ScalarType &gt; dtype, c10::optional&lt; Layout &gt; layout, c10::optional&lt; Device &gt; device, c10::optional&lt; bool &gt; pin_memory)</argsstring>
+  <name>arange</name>
+  <param>
+    <type>Scalar</type>
+    <declname>start</declname>
+  </param>
+  <param>
+    <type>Scalar</type>
+    <declname>end</declname>
+  </param>
+  <param>
+    <type><ref refid="classc10_1_1optional" kindref="compound">c10::optional</ref>&lt; ScalarType &gt;</type>
+    <declname>dtype</declname>
+  </param>
+  <param>
+    <type><ref refid="classc10_1_1optional" kindref="compound">c10::optional</ref>&lt; Layout &gt;</type>
+    <declname>layout</declname>
+  </param>
+  <param>
+    <type><ref refid="classc10_1_1optional" kindref="compound">c10::optional</ref>&lt; Device &gt;</type>
+    <declname>device</declname>
+  </param>
+  <param>
+    <type><ref refid="classc10_1_1optional" kindref="compound">c10::optional</ref>&lt; bool &gt;</type>
+    <declname>pin_memory</declname>
+  </param>
+</memberdef>
+<memberdef kind="function" id="5" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+  <type><ref refid="classat_1_1_tensor" kindref="compound">Tensor</ref></type>
+  <definition>Tensor at::arange</definition>
+  <argsstring>(Scalar start, Scalar end, Scalar step, const TensorOptions &amp;options={})</argsstring>
+  <name>range</name>
+  <param>
+    <type>Scalar</type>
+    <declname>start</declname>
+  </param>
+  <param>
+    <type>Scalar</type>
+    <declname>end</declname>
+  </param>
+  <param>
+    <type>Scalar</type>
+    <declname>step</declname>
+  </param>
+  <param>
+    <type>const TensorOptions &amp;</type>
+    <declname>options</declname>
+    <defval>{}</defval>
+  </param>
+</memberdef>
+<memberdef kind="function" id="6" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+  <type><ref refid="classat_1_1_tensor" kindref="compound">Tensor</ref></type>
+  <definition>Tensor at::arange</definition>
+  <argsstring>(Scalar start, Scalar end, Scalar step, c10::optional&lt; ScalarType &gt; dtype, c10::optional&lt; Layout &gt; layout, c10::optional&lt; Device &gt; device, c10::optional&lt; bool &gt; pin_memory)</argsstring>
+  <name>range</name>
+  <param>
+    <type>Scalar</type>
+    <declname>start</declname>
+  </param>
+  <param>
+    <type>Scalar</type>
+    <declname>end</declname>
+  </param>
+  <param>
+    <type>Scalar</type>
+    <declname>step</declname>
+  </param>
+  <param>
+    <type><ref refid="classc10_1_1optional" kindref="compound">c10::optional</ref>&lt; ScalarType &gt;</type>
+    <declname>dtype</declname>
+  </param>
+  <param>
+    <type><ref refid="classc10_1_1optional" kindref="compound">c10::optional</ref>&lt; Layout &gt;</type>
+    <declname>layout</declname>
+  </param>
+  <param>
+    <type><ref refid="classc10_1_1optional" kindref="compound">c10::optional</ref>&lt; Device &gt;</type>
+    <declname>device</declname>
+  </param>
+  <param>
+    <type><ref refid="classc10_1_1optional" kindref="compound">c10::optional</ref>&lt; bool &gt;</type>
+    <declname>pin_memory</declname>
+  </param>
+</memberdef>
+</sectiondef>

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,3 +1,4 @@
+import os
 import pytest  # type: ignore
 
 import sphinx.addnodes
@@ -403,3 +404,54 @@ def test_render_innergroup(app):
                for el in render(app, compound_def,
                                 compound_parser=mock_compound_parser,
                                 options=['inner']))
+
+def test_resolve_function(app):
+    from breathe.directives import DoxygenFunctionDirective
+    from breathe.project import ProjectInfoFactory
+    from breathe.parser import DoxygenParserFactory
+    from breathe.parser.compoundsuper import sectiondefType
+    from breathe.finder.factory import FinderFactory
+    from docutils.statemachine import StringList
+    from xml.dom import minidom
+
+    app.config.breathe_separate_member_pages = False
+    app.config.breathe_default_project = 'test_project'
+    app.config.breathe_domain_by_extension = {}
+    app.config.breathe_domain_by_file_pattern = {}
+    app.config.breathe_use_project_refids = False
+    project_info_factory = ProjectInfoFactory(app)
+    parser_factory = DoxygenParserFactory(app)
+    finder_factory = FinderFactory(app, parser_factory)
+    cls_args = ('doxygenclass', ['at::Tensor'],
+                {'members': '', 'protected-members': None, 'undoc-members': None},
+                StringList([], items=[]),
+                20, 24,
+                ('.. doxygenclass:: at::Tensor\n   :members:\n'
+                        '   :protected-members:\n   :undoc-members:'),
+                MockState(app),
+                MockStateMachine(),
+               )
+    cls = DoxygenFunctionDirective(finder_factory, project_info_factory, parser_factory, *cls_args)
+
+    argsstrings = []
+    with open(os.path.join(os.path.dirname(__file__), 'data', 'arange.xml')) as fid:
+        xml = fid.read()
+    doc = minidom.parseString(xml)
+
+    sectiondef = sectiondefType.factory()
+    for child in doc.documentElement.childNodes:
+        sectiondef.buildChildren(child, 'memberdef')
+        if getattr(child, 'tagName', None) == 'memberdef':
+            # Get the argsstring function declaration
+            argsstrings.append(child.getElementsByTagName('argsstring')[0].childNodes[0].data)
+
+    # Verify that parsing the exact same argument works
+    matches = [[m, sectiondef] for m in sectiondef.memberdef]
+    for args in argsstrings:
+        ast_param = cls.parse_args(args)
+        ret = cls.resolve_function(matches, ast_param, None)
+
+    # Make sure matching will suceed even if the initializers are missing
+    # Take the default argument off argsstrings[0] to test
+    ast_param = cls.parse_args('(Scalar end, const TensorOptions &options)')
+    ret = cls.resolve_function(matches, ast_param, None)

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -450,8 +450,3 @@ def test_resolve_function(app):
     for args in argsstrings:
         ast_param = cls.parse_args(args)
         ret = cls.resolve_function(matches, ast_param, None)
-
-    # Make sure matching will suceed even if the initializers are missing
-    # Take the default argument off argsstrings[0] to test
-    ast_param = cls.parse_args('(Scalar end, const TensorOptions &options)')
-    ret = cls.resolve_function(matches, ast_param, None)


### PR DESCRIPTION
I added the test from michaeljones/breathe#605 (tweaked as per comments), which passed. But it was missing something. The `rst` directives as generated by exhale and doxygen (maybe breathe is involved, I don't know) seem to generate `doxygenfunction` directives without the initial arguments. This trips up the matching function, so I added a test and a fix for removing the initial arguments. Arguably, the problem is that the directive should be created with initial arguments, but this small fix on top of your PR makes document generation in pytorch much happier.